### PR TITLE
change a retun type of get_vote_info fromm BoundedVec to Vec

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -36,7 +36,7 @@ pub use frame_support::{
 		},
 		IdentityFee, Weight,
 	},
-	BoundedVec, StorageValue,
+	StorageValue,
 };
 pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
@@ -477,8 +477,8 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl proof_of_transaction_runtime_api::ProofOfTransactionAPI<Block, AccountId, <Runtime as pallet_pot::Config>::MaxVotedValidators> for Runtime {
-		fn get_vote_info() -> BoundedVec<(AccountId, u64), MaxVotedValidators> {
+	impl proof_of_transaction_runtime_api::ProofOfTransactionAPI<Block, AccountId> for Runtime {
+		fn get_vote_info() -> Vec<(AccountId, VoteWeight)> {
 			pallet_pot::Pallet::<Runtime>::get_vote_info()
 		}
 	}

--- a/frame/proof-of-transaction/runtime-api/src/lib.rs
+++ b/frame/proof-of-transaction/runtime-api/src/lib.rs
@@ -19,13 +19,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::{traits::Get, BoundedVec};
-
 sp_api::decl_runtime_apis! {
 	#[api_version(3)]
-	pub trait ProofOfTransactionAPI<AccountId, MaxVotedValidators: Get<u32>> where
+	pub trait ProofOfTransactionAPI<AccountId> where
 		AccountId: codec::Codec,
 	{
-		fn get_vote_info() -> BoundedVec<(AccountId, u64), MaxVotedValidators>;
+		fn get_vote_info() -> Vec<(AccountId, u64)>;
 	}
 }

--- a/frame/proof-of-transaction/src/lib.rs
+++ b/frame/proof-of-transaction/src/lib.rs
@@ -10,7 +10,6 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	dispatch::{DispatchInfo, PostDispatchInfo},
 	pallet_prelude::*,
-	BoundedVec,
 };
 
 pub use pallet::*;
@@ -20,7 +19,7 @@ use sp_runtime::{
 	transaction_validity::{TransactionValidity, TransactionValidityError, ValidTransaction},
 };
 
-use sp_std::{convert::TryInto, prelude::*, vec::Vec};
+use sp_std::{prelude::*, vec::Vec};
 
 pub type VoteWeight = u64;
 
@@ -73,14 +72,11 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	/// Runtime-api fn to return and change the collected VoteInfo as a BoundedVec
-	pub fn get_vote_info() -> BoundedVec<(T::AccountId, VoteWeight), T::MaxVotedValidators> {
+	/// Runtime-api fn to return the collected VoteInfo as a Vec
+	pub fn get_vote_info() -> Vec<(T::AccountId, VoteWeight)> {
 		let vote_vec = VoteInfo::<T>::iter().collect::<Vec<(T::AccountId, VoteWeight)>>();
 
-		let vote_bounded: BoundedVec<(T::AccountId, VoteWeight), T::MaxVotedValidators> =
-			vote_vec.try_into().expect("exceeded the # of validators available to vote.");
-
-		vote_bounded
+		vote_vec
 	}
 
 	pub fn get_max_voted_validators() -> u32 {


### PR DESCRIPTION
### Summary
* change a retun type of get_vote_info fromm BoundedVec to Vec

### Describe your changes
* modify the return type of vote info in pot_pallet, runtime_api and node template
* remove unused variables and packages


### Related Issue
* #8

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Well documented code
- [x] `cargo clippy`
- [x] `cargo-nightly fmt`
