### PR TITLE
Feature/20-add-actual-fee

### DIFF
--- a/frame/support/src/traits/pot.rs
+++ b/frame/support/src/traits/pot.rs
@@ -1,4 +1,3 @@
-use super::tokens::fungibles;
 use crate::sp_runtime::generic::{VoteAssetId, VoteWeight};
 
 /// An interface for dealing with vote info

--- a/frame/transaction-payment/infra-asset-tx-payment/src/lib.rs
+++ b/frame/transaction-payment/infra-asset-tx-payment/src/lib.rs
@@ -312,10 +312,10 @@ where
 							already_withdrawn.into(),
 						)?;
 
-					// let con_asset_id = asset_id.unwrap();
+					let con_asset_id = asset_id.unwrap();
 
-					// // asset_id can be unwrapped in this scope
-					// T::VoteInfoHandler::update_vote_info(who, con_asset_id, converted_fee);
+					// asset_id can be unwrapped in this scope
+					T::VoteInfoHandler::update_vote_info(&who, con_asset_id, converted_fee);
 
 					Pallet::<T>::deposit_event(Event::<T>::AssetTxFeePaid {
 						who,

--- a/frame/transaction-payment/infra-asset-tx-payment/src/lib.rs
+++ b/frame/transaction-payment/infra-asset-tx-payment/src/lib.rs
@@ -220,6 +220,8 @@ where
 	BalanceOf<T>: Send + Sync + From<u64> + FixedPointOperand + IsType<ChargeAssetBalanceOf<T>>,
 	ChargeAssetIdOf<T>: Send + Sync,
 	CreditOf<T::AccountId, T::Fungibles>: IsType<ChargeAssetLiquidityOf<T>>,
+	u32: From<<<T as pallet::Config>::OnChargeAssetTransaction as payment::OnChargeAssetTransaction<T>>::AssetId>,
+	u64: From<<<T as pallet::Config>::Fungibles as frame_support::traits::fungibles::Inspect<<T as frame_system::Config>::AccountId>>::Balance>
 {
 	const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
 	type AccountId = T::AccountId;
@@ -312,10 +314,15 @@ where
 							already_withdrawn.into(),
 						)?;
 
-					let con_asset_id = asset_id.unwrap();
-
-					// asset_id can be unwrapped in this scope
-					T::VoteInfoHandler::update_vote_info(&who, con_asset_id, converted_fee);
+					// update_vote_info is only excuted when vote_info has some data 
+					if let Some(candi) = &vote_info{
+						T::VoteInfoHandler::update_vote_info(
+							candi.clone(),
+							// asset_id should be unwrapped in this scope
+							asset_id.unwrap().into(),
+							converted_fee.into(),
+						);
+					}
 
 					Pallet::<T>::deposit_event(Event::<T>::AssetTxFeePaid {
 						who,

--- a/frame/transaction-payment/infra-asset-tx-payment/src/mock.rs
+++ b/frame/transaction-payment/infra-asset-tx-payment/src/mock.rs
@@ -15,7 +15,6 @@
 
 use super::*;
 use crate as pallet_infra_asset_tx_payment;
-
 use codec;
 use frame_support::{
 	dispatch::DispatchClass,
@@ -32,6 +31,7 @@ use frame_system::EnsureRoot;
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_core::H256;
 use sp_runtime::{
+	generic::{VoteAssetId, VoteWeight},
 	testing::Header,
 	traits::{BlakeTwo256, ConvertInto, IdentityLookup, SaturatedConversion},
 };
@@ -203,6 +203,18 @@ impl HandleCredit<AccountId, Assets> for CreditToBlockAuthor {
 	}
 }
 
+pub struct MockVoteInfo<AccountId> {
+	pub who: AccountId,
+	pub asset_id: VoteAssetId,
+	pub vote_weight: VoteWeight,
+}
+
+impl VoteInfoHandler<AccountId> for MockVoteInfo<AccountId> {
+	fn update_vote_info(_who: AccountId, _asset_id: VoteAssetId, _vote_weight: VoteWeight) {
+		// this dummy body should be replaced to work fine
+	}
+}
+
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Fungibles = Assets;
@@ -210,5 +222,5 @@ impl Config for Runtime {
 		pallet_assets::BalanceToAssetBalance<Balances, Runtime, ConvertInto>,
 		CreditToBlockAuthor,
 	>;
-	type VoteInfoHandler = VoteInfoHandler<Self::AccountId, Self::Fungibles>;
+	type VoteInfoHandler = MockVoteInfo<AccountId>;
 }

--- a/frame/transaction-payment/infra-asset-tx-payment/src/mock.rs
+++ b/frame/transaction-payment/infra-asset-tx-payment/src/mock.rs
@@ -210,5 +210,5 @@ impl Config for Runtime {
 		pallet_assets::BalanceToAssetBalance<Balances, Runtime, ConvertInto>,
 		CreditToBlockAuthor,
 	>;
-	// type VoteInfoHandler = VoteInfoHandler<Self::AccountId, Self::Fungibles>;
+	type VoteInfoHandler = VoteInfoHandler<Self::AccountId, Self::Fungibles>;
 }

--- a/primitives/runtime/src/generic/vote.rs
+++ b/primitives/runtime/src/generic/vote.rs
@@ -1,6 +1,7 @@
 pub type VoteWeight = u64;
 pub type VoteAssetId = u32;
 
+/// The concrete type for VoteInfo
 pub struct VoteInfo<AccountId> {
 	pub who: AccountId,
 	pub asset_id: VoteAssetId,


### PR DESCRIPTION
### Summary
* update vote_info in post_dispatch
* after tx is dispatched, 
* vote_info = (AddressId, AssetId, VoteWeight)

### Describe your changes
* Candidate, AssetId, VoteWeight is stored by calling update_vote info function of VoteInfoHandler
* update_vote_info is only excuted when vote_info has some data 

### Related Issue
* #20 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Well documented code
- [ ] `cargo clippy`
- [ ] `cargo-nightly fmt`
