### PR TITLE
Infra Voting Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6072,6 +6072,7 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-application-crypto",
  "sp-core",
  "sp-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6076,8 +6076,10 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-io",
+ "sp-keyring",
  "sp-runtime",
  "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]

--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -48,7 +48,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		VoteCollected { who: T::AccountId, asset_id: VoteAssetId, vote_weight: VoteWeight },
 	}

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -13,7 +13,7 @@ use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
-		AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, One, Verify
+		AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, One, Verify,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, MultiSignature,

--- a/frame/infra-voting/Cargo.toml
+++ b/frame/infra-voting/Cargo.toml
@@ -24,10 +24,15 @@ sp-io = { version = "7.0.0", default-features = false, path = "../../primitives/
 sp-runtime = { version = "7.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../primitives/std" }
 
+[dev-dependencies]
+sp-tracing = { version = "6.0.0", path = "../../primitives/tracing" }
+sp-keyring = { version = "7.0.0", default-features = false, path = "../../primitives/keyring" }
+
 [features]
 default = ["std"]
 std = [
 	"frame-benchmarking?/std",
+	"serde",
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/frame/infra-voting/Cargo.toml
+++ b/frame/infra-voting/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/InfraBlockChain/substrate/"
 description = "FRAME's Infra Voting"
 
 [dependencies]
+serde = { version = "1.0.136", optional = true }
 codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }

--- a/frame/infra-voting/src/impls.rs
+++ b/frame/infra-voting/src/impls.rs
@@ -1,6 +1,7 @@
+
 use crate::*;
 
-pub type MaxValidatorsOf<T> = <T as Config>::MaxValidators;
+pub type TotalNumValidatorsOf<T> = <T as Config>::TotalNumberOfValidators;
 /// Means for interacting with a specialized version of the `session` trait.
 pub trait SessionInterface<AccountId> {
 	/// Disable the validator at the given index, returns `false` if the validator was already
@@ -25,28 +26,49 @@ impl<AccountId> SessionInterface<AccountId> for () {
 }
 
 pub trait VotingHandler<T> {
-	fn update_vote_weight(session_index: SessionIndex, who: VoteAccountId, weight: VoteWeight);
+	fn update_vote_status(era_index: SessionIndex, who: VoteAccountId, weight: VoteWeight);
 }
 
 impl<T: Config> VotingHandler<T> for Pallet<T> {
-	fn update_vote_weight(session_index: SessionIndex, who: VoteAccountId, weight: VoteWeight) {
-		let vote_id: T::InfraVoteId = who.into();
+	fn update_vote_status(era_index: SessionIndex, who: VoteAccountId, weight: VoteWeight) {
+		let vote_account_id: T::InfraVoteAccountId = who.into();
 		let vote_points: T::InfraVotePoints = weight.into();
 
-		let mut vote_status = VotingStatusPerSession::<T>::get(&session_index, &vote_id);
-		vote_status.increase_weight(&vote_id, vote_points);
-		Pallet::<T>::deposit_event(Event::<T>::VotePointsAdded {
-			session_index,
-			who: vote_id,
-			points: vote_points,
-		})
+		let mut vote_status = VotingStatusPerEra::<T>::get(&era_index);
+		vote_status.add_points(&vote_account_id, vote_points);
 	}
 }
 
 impl<T: Config> VotingHandler<T> for () {
-	fn update_vote_weight(_: SessionIndex, _: VoteAccountId, _: VoteWeight) {}
+	fn update_vote_status(_: SessionIndex, _: VoteAccountId, _: VoteWeight) {}
 }
 
+// Session Pallet Rotate Order
+//
+// On Genesis:
+// `new_session_genesis()` is called
+//
+// After Genesis:
+// `on_initialize(block_number)` when session is about to end
+// `end_session(bn)` -> `start_session(bn+1)` -> `new_session(bn+2)` are called this order
+//
+// Detail
+// 1. new_session()
+// - Plan a new session and optionally returns Validator Set
+// - Potentially plan a new era
+// - Internally `trigger_new_era()` is called when planning a new era
+//
+// 2. new_session_genesis()
+// - Called only once at genesis
+// - If there is no validator set returned, session pallet's config keys are used for initial validator set
+//
+// 3. start_session()
+// - Start a session potentially starting an era
+// - Internally `start_era()` is called when starting a new era
+// 
+// 4. end_session()
+// - End a session potentially ending an era
+// - Internally `end_era()` is called when ending an era
 impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
 	fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
 		log!(trace, "planning new session {}", new_index);
@@ -58,32 +80,134 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
 	}
 	fn start_session(start_index: SessionIndex) {
 		log!(trace, "starting session {}", start_index);
-		Self::handle_start_session(start_index);
 	}
 	fn end_session(end_index: SessionIndex) {
 		log!(trace, "ending session {}", end_index);
-		Self::handle_end_session(end_index);
 	}
 }
 
 impl<T: Config> Pallet<T> {
+	
 	fn handle_new_session(
 		session_index: SessionIndex,
 		is_genesis: bool,
-	) -> Option<BoundedVec<T::AccountId, MaxValidatorsOf<T>>> {
+	) -> Option<BoundedVec<T::AccountId, TotalNumValidatorsOf<T>>> {
 		if let Some(current_era) = CurrentEra::<T>::get() {
-			None
+			let start_session_index = StartSessionIndexPerEra::<T>::get(current_era)
+				.unwrap_or_else(|| {
+					frame_support::print("Error: start_session_index must be set for current_era");
+					0
+				});
+				let era_length = session_index.saturating_sub(start_session_index); // Must never happen.
+
+				match ForceEra::<T>::get() {
+					// Will be set to `NotForcing` again if a new era has been triggered.
+					Forcing::ForceNew => (),
+					// Short circuit to `try_trigger_new_era`.
+					Forcing::ForceAlways => (),
+					// Only go to `try_trigger_new_era` if deadline reached.
+					Forcing::NotForcing if era_length >= T::SessionsPerEra::get() => (),
+					_ => {
+						// Either `Forcing::ForceNone`,
+						// or `Forcing::NotForcing if era_length < T::SessionsPerEra::get()`.
+						return None
+					},
+				}
+
+			// New era.
+			let maybe_new_era_validators = Self::do_trigger_new_era(session_index, is_genesis);
+			if maybe_new_era_validators.is_some() &&
+				matches!(ForceEra::<T>::get(), Forcing::ForceNew)
+			{
+				Self::set_force_era(Forcing::NotForcing);
+			}
+
+			maybe_new_era_validators
 		} else {
-			// Initial era
-			None
+			log!(debug, "Starting the first era.");
+			Self::do_trigger_new_era(session_index, is_genesis)
 		}
 	}
 
-	fn handle_start_session(session_index: SessionIndex) {
+	/// Plan a new era.
+	///
+	/// * Bump the current era storage (which holds the latest planned era).
+	/// * Store start session index for the new planned era.
+	/// * Clean old era information.
+	/// * Store staking information for the new planned era
+	///
+	/// Returns the new validator set.
+	fn do_trigger_new_era(
+		session_index: SessionIndex, 
+		_is_genesis: bool
+	) -> Option<BoundedVec<T::AccountId, TotalNumValidatorsOf<T>>> {
 		
+		let new_planned_era = CurrentEra::<T>::mutate(|era| {
+			*era = Some(era.map(|old_era| old_era+1).unwrap_or(0));
+			era.unwrap()
+		});
+		StartSessionIndexPerEra::<T>::insert(&new_planned_era, session_index);
+		Some(Self::elect_validators(session_index))
+
+		// Clean old era information.
+		// Later
+		// if let Some(old_era) = new_planned_era.checked_sub(T::HistoryDepth::get() + 1) {
+		// 	Self::clear_era_information(old_era);
+		// }
 	}
 
-	fn handle_end_session(session_index: SessionIndex) {
+	/// Elect validators from `SeedTrustValidatorPool::<T>` and `PotValidatorPool::<T>`
+	/// 
+	/// First, check the number of seed trust validator.
+	/// If it is equal to number of max validators, we just elect from `SeedTrustValidatorPool::<T>`.
+	/// Otherwise, remain number of validators are elected from `PotValidatorPool::<T>`.
+	pub fn elect_validators(
+		era_index: EraIndex
+	) -> BoundedVec<T::AccountId, TotalNumValidatorsOf<T>> {
 
-	} 
+		let validators = Self::do_elect_validators(era_index);
+		validators.try_into().expect("Should be equal to total number of validators")
+	}
+
+	fn do_elect_validators(era_index: EraIndex) -> Vec<T::AccountId> {
+		let total_num_validators = T::TotalNumberOfValidators::get();
+		let num_seed_trust = NumberOfSeedTrustValidators::<T>::get();
+		let num_pot = total_num_validators - num_seed_trust;
+		let mut pot_enabled = false;
+		let mut validators: Vec<T::AccountId> = Self::do_elect_seed_trust_validators(num_seed_trust);
+		if num_pot != 0 {
+			let mut pot_validators = Self::do_elect_pot_validators(era_index, num_pot);
+			pot_enabled = true;
+			validators.append(&mut pot_validators);
+		}
+		assert!(validators.len() <= total_num_validators as usize, "Should be less or equal to total number of validators");
+		Self::deposit_event(Event::<T>::ValidatorsElected { pot_enabled });
+		validators
+	}
+
+	fn do_elect_seed_trust_validators(num_seed_trust: u32) -> Vec<T::AccountId> {
+		let seed_trust_validators = SeedTrustValidatorPool::<T>::get();
+		Self::deposit_event(Event::<T>::SeedTrustValidatorsElected);
+		seed_trust_validators
+			.iter()
+			.take(num_seed_trust as usize)
+			.cloned()
+			.collect::<Vec<_>>()
+	}
+
+	fn do_elect_pot_validators(era_index: EraIndex, num_pot: u32) -> Vec<T::AccountId> {
+		// PoT election phase 
+		let mut voting_status = VotingStatusPerEra::<T>::get(&era_index);
+		voting_status.sort_by_vote_points();
+		let pot_validators = voting_status.get_top_validators(num_pot).clone();
+		Self::deposit_event(Event::<T>::PotValidatorsElected);
+		pot_validators.try_into().expect("Should be less than total number of validators")
+	}
+
+	/// Helper to set a new `ForceEra` mode.
+	pub fn set_force_era(mode: Forcing) {
+		log!(info, "Setting force era mode {:?}.", mode);
+		ForceEra::<T>::put(mode);
+		Self::deposit_event(Event::<T>::ForceEra { mode });
+	}
 }

--- a/frame/infra-voting/src/impls.rs
+++ b/frame/infra-voting/src/impls.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+pub type MaxValidatorsOf<T> = <T as Config>::MaxValidators;
 /// Means for interacting with a specialized version of the `session` trait.
 pub trait SessionInterface<AccountId> {
 	/// Disable the validator at the given index, returns `false` if the validator was already
@@ -47,9 +48,42 @@ impl<T: Config> VotingHandler<T> for () {
 }
 
 impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
-	fn new_session(_new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
-		None
+	fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
+		log!(trace, "planning new session {}", new_index);
+		Self::handle_new_session(new_index, false).map(|v| v.into_inner())
 	}
-	fn start_session(_start_index: SessionIndex) {}
-	fn end_session(_end_index: SessionIndex) {}
+	fn new_session_genesis(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
+		log!(trace, "planning new session {} at genesis", new_index);
+		Self::handle_new_session(new_index, true).map(|v| v.into_inner())
+	}
+	fn start_session(start_index: SessionIndex) {
+		log!(trace, "starting session {}", start_index);
+		Self::handle_start_session(start_index);
+	}
+	fn end_session(end_index: SessionIndex) {
+		log!(trace, "ending session {}", end_index);
+		Self::handle_end_session(end_index);
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	fn handle_new_session(
+		session_index: SessionIndex,
+		is_genesis: bool,
+	) -> Option<BoundedVec<T::AccountId, MaxValidatorsOf<T>>> {
+		if let Some(current_era) = CurrentEra::<T>::get() {
+			None
+		} else {
+			// Initial era
+			None
+		}
+	}
+
+	fn handle_start_session(session_index: SessionIndex) {
+		
+	}
+
+	fn handle_end_session(session_index: SessionIndex) {
+
+	} 
 }

--- a/frame/infra-voting/src/lib.rs
+++ b/frame/infra-voting/src/lib.rs
@@ -14,7 +14,7 @@ use sp_runtime::{
 };
 
 #[cfg(test)]
-mod tests; 
+mod tests;
 
 #[cfg(test)]
 pub mod mock;
@@ -66,7 +66,6 @@ pub struct VotingStatus<T: Config> {
 	pub status: Vec<(T::InfraVoteAccountId, T::InfraVotePoints)>,
 }
 
-
 impl<T: Config> Default for VotingStatus<T> {
 	fn default() -> Self {
 		Self { status: Default::default() }
@@ -96,8 +95,8 @@ impl<T: Config> VotingStatus<T> {
 
 	/// Get top validators for given vote status.
 	/// We elect validators based on PoT which has exceeded the minimum vote points.
-	/// 
-	/// Note: 
+	///
+	/// Note:
 	/// This function should be called after `sort_by_vote_points` is called.
 	pub fn top_validators(&mut self, num: u32) -> Vec<T::AccountId> {
 		self.status
@@ -106,7 +105,7 @@ impl<T: Config> VotingStatus<T> {
 			.filter(|vote_status| vote_status.1 >= MinVotePointsThreshold::<T>::get().into())
 			.map(|vote_status| vote_status.0.clone().into())
 			.collect()
-	}  
+	}
 }
 
 #[frame_support::pallet]
@@ -165,7 +164,7 @@ pub mod pallet {
 		pub number_of_seed_trust_validators: u32,
 		pub force_era: Forcing,
 		pub is_pot_enable_at_genesis: bool,
-		pub vote_status_at_genesis: Vec<(T::InfraVoteAccountId, T::InfraVotePoints)>
+		pub vote_status_at_genesis: Vec<(T::InfraVoteAccountId, T::InfraVotePoints)>,
 	}
 
 	#[cfg(feature = "std")]
@@ -174,7 +173,7 @@ pub mod pallet {
 			GenesisConfig {
 				is_pot_enable_at_genesis: false,
 				seed_trust_validators: Default::default(),
-				total_number_of_validators: Default::default(),	
+				total_number_of_validators: Default::default(),
 				number_of_seed_trust_validators: Default::default(),
 				force_era: Default::default(),
 				vote_status_at_genesis: Default::default(),
@@ -211,7 +210,7 @@ pub mod pallet {
 		/// Seed trust validator has been added to the pool
 		SeedTrustAdded { who: T::AccountId },
 		/// Validator have been elected
-		ValidatorsElected { validators: Vec<T::AccountId>, pot_enabled: bool }, 
+		ValidatorsElected { validators: Vec<T::AccountId>, pot_enabled: bool },
 		/// Seed Trust validators have been elected
 		SeedTrustValidatorsElected,
 		/// Validators have been elected by PoT
@@ -241,8 +240,7 @@ pub mod pallet {
 	// Validators set of Seed Trust
 	#[pallet::storage]
 	#[pallet::unbounded]
-	pub type SeedTrustValidatorPool<T: Config> =
-		StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+	pub type SeedTrustValidatorPool<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
 	/// Validators which have been elected by PoT at certain era index
 	#[pallet::storage]
@@ -252,20 +250,20 @@ pub mod pallet {
 
 	/// Number of seed trust validators that can be elected
 	#[pallet::storage]
-	pub type NumberOfSeedTrustValidators<T: Config> = 
-		StorageValue<_, u32, ValueQuery>;
+	pub type NumberOfSeedTrustValidators<T: Config> = StorageValue<_, u32, ValueQuery>;
 
-	/// Total Number of validators that can be elected, 
+	/// Total Number of validators that can be elected,
 	/// which is composed of seed trust validators and pot validators
 	#[pallet::storage]
 	pub type TotalNumberOfValidators<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	#[pallet::storage]
 	pub type MinVotePointsThreshold<T: Config> = StorageValue<_, VoteWeight, ValueQuery>;
-	
+
 	/// Start Session index for era
 	#[pallet::storage]
-	pub type StartSessionIndexPerEra<T: Config> = StorageMap<_, Twox64Concat, EraIndex, SessionIndex, OptionQuery>; 
+	pub type StartSessionIndexPerEra<T: Config> =
+		StorageMap<_, Twox64Concat, EraIndex, SessionIndex, OptionQuery>;
 
 	/// Mode of era forcing.
 	#[pallet::storage]
@@ -285,7 +283,10 @@ pub mod pallet {
 			// Only root can call
 			ensure_root(origin)?;
 			// Seed Trust validators number should be less than max validators
-			ensure!(num_validators <= TotalNumberOfValidators::<T>::get(), Error::<T>::SeedTrustExceedMaxValidators);
+			ensure!(
+				num_validators <= TotalNumberOfValidators::<T>::get(),
+				Error::<T>::SeedTrustExceedMaxValidators
+			);
 			NumberOfSeedTrustValidators::<T>::put(num_validators);
 			Self::deposit_event(Event::<T>::SeedTrustNumChanged);
 			Ok(())
@@ -305,10 +306,7 @@ pub mod pallet {
 
 		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
-		pub fn add_seed_trust_validator(
-			origin: OriginFor<T>,
-			who: T::AccountId,
-		) -> DispatchResult {
+		pub fn add_seed_trust_validator(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
 			// Only root can call
 			ensure_root(origin)?;
 			let mut seed_trust_validators = SeedTrustValidatorPool::<T>::get();

--- a/frame/infra-voting/src/lib.rs
+++ b/frame/infra-voting/src/lib.rs
@@ -35,10 +35,32 @@ macro_rules! log {
 		)
 	};
 }
+
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+// #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub enum Forcing {
+	/// Not forcing anything - just let whatever happen.
+	NotForcing,
+	/// Force a new era, then reset to `NotForcing` as soon as it is done.
+	/// Note that this will force to trigger an election until a new era is triggered, if the
+	/// election failed, the next session end will trigger a new election again, until success.
+	ForceNew,
+	/// Avoid a new era indefinitely.
+	ForceNone,
+	/// Force a new era at the end of all sessions indefinitely.
+	ForceAlways,
+}
+
+impl Default for Forcing {
+	fn default() -> Self {
+		Forcing::NotForcing
+	}
+}
+
 #[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct VotingStatus<T: Config> {
-	pub status: Vec<(T::InfraVoteId, T::InfraVotePoints)>,
+	pub status: Vec<(T::InfraVoteAccountId, T::InfraVotePoints)>,
 }
 
 impl<T: Config> Default for VotingStatus<T> {
@@ -48,15 +70,35 @@ impl<T: Config> Default for VotingStatus<T> {
 }
 
 impl<T: Config> VotingStatus<T> {
-	pub fn increase_weight(&mut self, who: &T::InfraVoteId, weight: T::InfraVotePoints) {
+	/// Add vote point for given vote account id and vote points.
+	pub fn add_points(&mut self, who: &T::InfraVoteAccountId, vote_points: T::InfraVotePoints) {
 		for s in self.status.iter_mut() {
 			if &s.0 == who {
-				s.1 = s.1.clone().saturating_add(weight.into());
+				s.1 = s.1.clone().saturating_add(vote_points.into());
 				return
 			}
 		}
-		self.status.push((who.clone(), weight.into()));
+		self.status.push((who.clone(), vote_points.into()));
 	}
+
+	/// Sort vote status for decreasing order
+	pub fn sort_by_vote_points(&mut self) {
+		self.status.sort_by(|x, y| y.1.cmp(&x.1));
+	}
+
+	/// Get top validators for given vote status.
+	/// We elect validators based on PoT which has exceeded the minimum vote points.
+	/// 
+	/// Note: 
+	/// This function should be called after `sort_by_vote_points` is called.
+	pub fn get_top_validators(&mut self, num: u32) -> Vec<T::AccountId> {
+		self.status
+			.iter()
+			.take(num as usize)
+			.filter(|vote_status| vote_status.1 >= T::MinVotePointsThreshold::get().into())
+			.map(|vote_status| vote_status.0.clone().into())
+			.collect()
+	}  
 }
 
 #[frame_support::pallet]
@@ -74,20 +116,29 @@ pub mod pallet {
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// Max number of validators that can be elected, 
+		/// Total Number of validators that can be elected, 
 		/// which is composed of seed trust validators and pot validators
 		#[pallet::constant]
-		type MaxValidators: Get<u32>;
+		type TotalNumberOfValidators: Get<u32>;
+
+		/// Minimum vote points to be elected
+		#[pallet::constant]
+		type MinVotePointsThreshold: Get<u32>;
+
+		/// Number of sessions per era.
+		#[pallet::constant]
+		type SessionsPerEra: Get<SessionIndex>;
 
 		/// Simply the vote account id type for vote
-		type InfraVoteId: Parameter
+		type InfraVoteAccountId: Parameter
 			+ Member
 			+ MaybeSerializeDeserialize
 			+ sp_std::fmt::Debug
 			+ MaybeDisplay
 			+ Ord
 			+ MaxEncodedLen
-			+ From<VoteAccountId>;
+			+ From<VoteAccountId>
+			+ IsType<<Self as frame_system::Config>::AccountId>;
 
 		/// Simply the vote weight type for election
 		type InfraVotePoints: sp_runtime::traits::AtLeast32BitUnsigned
@@ -104,10 +155,6 @@ pub mod pallet {
 		/// guess.
 		type NextNewSession: EstimateNextNewSession<Self::BlockNumber>;
 
-		/// Number of sessions per era.
-		#[pallet::constant]
-		type SessionsPerEra: Get<SessionIndex>;
-
 		/// Interface for interacting with a session pallet.
 		type SessionInterface: SessionInterface<Self::AccountId>;
 	}
@@ -116,14 +163,25 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// Points has been added for candidate validator
-		VotePointsAdded { session_index: SessionIndex, who: T::InfraVoteId, points: T::InfraVotePoints },
-		/// Pot status has been changed
-		PotStatusChanged { status: bool },
+		VotePointsAdded { who: T::InfraVoteAccountId },
+		/// Number of seed trust validators has been changed
+		SeedTrustNumChanged,
+		/// Seed trust validator has been added to the pool
+		SeedTrustAdded { who: T::AccountId },
+		/// Validator have been elected
+		ValidatorsElected { pot_enabled: bool }, 
+		/// Seed Trust validators have been elected
+		SeedTrustValidatorsElected,
+		/// Validators have been elected by PoT
+		PotValidatorsElected,
+		/// A new force era mode was set.
+		ForceEra { mode: Forcing },
 	}
 
 	#[pallet::error]
 	pub enum Error<T> {
 		SeedTrustExceedMaxValidators,
+		NotActiveValidator,
 	}
 
 	/// The current era index.
@@ -133,15 +191,13 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type CurrentEra<T> = StorageValue<_, EraIndex, OptionQuery>;
 
-	// Voting status mapped to session index and infra vote id
+	// Voting status for each era
 	#[pallet::storage]
 	#[pallet::unbounded]
-	pub type VotingStatusPerSession<T: Config> = StorageDoubleMap<
+	pub type VotingStatusPerEra<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
-		SessionIndex,
-		Twox64Concat,
-		T::InfraVoteId,
+		EraIndex,
 		VotingStatus<T>,
 		ValueQuery,
 	>;
@@ -149,23 +205,27 @@ pub mod pallet {
 	// Current validators that are composed of seed trust validators and optional pot validators
 	#[pallet::storage]
 	pub type ValidatorPool<T: Config> =
-		StorageValue<_, BoundedVec<T::AccountId, T::MaxValidators>, ValueQuery>;
+		StorageValue<_, BoundedVec<T::AccountId, T::TotalNumberOfValidators>, ValueQuery>;
 
-	// Validators set to seed trust will be stored here
+	// Validators set of Seed Trust
 	#[pallet::storage]
 	#[pallet::unbounded]
 	pub type SeedTrustValidatorPool<T: Config> =
-		StorageValue<_, Vec<T::AccountId>, OptionQuery>;
+		StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
-	// Validators elected by pot will be stored here
-	#[pallet::storage]
-	#[pallet::unbounded]
-	pub type PotValidatorPool<T: Config> =
-		StorageValue<_, Vec<T::AccountId>, OptionQuery>;
-
+	/// Number of seed trust validators that can be elected
 	#[pallet::storage]
 	pub type NumberOfSeedTrustValidators<T: Config> = 
 		StorageValue<_, u32, ValueQuery>;
+	
+	/// Start Session index for era
+	#[pallet::storage]
+	pub type StartSessionIndexPerEra<T: Config> = StorageMap<_, Twox64Concat, EraIndex, SessionIndex, OptionQuery>; 
+
+	/// Mode of era forcing.
+	#[pallet::storage]
+	#[pallet::getter(fn force_era)]
+	pub type ForceEra<T> = StorageValue<_, Forcing, ValueQuery>;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -177,12 +237,27 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			num_validators: u32,
 		) -> DispatchResult {
-			// Only root can set pot status
+			// Only root can call
 			ensure_root(origin)?;
 			// Seed Trust validators number should be less than max validators
-			ensure!(num_validators <= T::MaxValidators::get(), Error::<T>::SeedTrustExceedMaxValidators);
+			ensure!(num_validators <= T::TotalNumberOfValidators::get(), Error::<T>::SeedTrustExceedMaxValidators);
 			NumberOfSeedTrustValidators::<T>::put(num_validators);
+			Self::deposit_event(Event::<T>::SeedTrustNumChanged);
+			Ok(())
+		}
 
+		#[pallet::call_index(1)]
+		#[pallet::weight(0)]
+		pub fn add_seed_trust_validator(
+			origin: OriginFor<T>,
+			who: T::AccountId,
+		) -> DispatchResult {
+			// Only root can call
+			ensure_root(origin)?;
+			let mut seed_trust_validators = SeedTrustValidatorPool::<T>::get();
+			seed_trust_validators.push(who.clone());
+			SeedTrustValidatorPool::<T>::put(seed_trust_validators);
+			Self::deposit_event(Event::<T>::SeedTrustAdded { who });
 			Ok(())
 		}
 	}

--- a/frame/infra-voting/src/mock.rs
+++ b/frame/infra-voting/src/mock.rs
@@ -1,0 +1,356 @@
+
+use frame_support::{
+	parameter_types,
+	traits::{ConstU32, ConstU64, GenesisBuild, OneSessionHandler, Hooks},
+};
+use std::collections::BTreeMap;
+use sp_core::{H256, ByteArray};
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup, Convert}, generic::{VoteAccountId, VoteWeight},
+    AccountId32,
+};
+use sp_keyring::Sr25519Keyring::*;
+use crate::{self as pallet_infra_voting, *};
+
+pub const BLOCK_TIME: u64 = 1000;
+
+/// The AccountId alias in this test module.
+pub(crate) type AccountId = AccountId32;
+pub(crate) type AccountIndex = u64;
+pub(crate) type BlockNumber = u64;
+pub(crate) type Balance = u128;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
+type Block = frame_system::mocking::MockBlock<TestRuntime>;
+frame_support::construct_runtime!(
+    pub enum TestRuntime where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
+        InfraVoting: pallet_infra_voting::{Pallet, Call, Storage, Config<T>, Event<T>},
+    }
+);
+
+impl frame_system::Config for TestRuntime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Index = AccountIndex;
+	type BlockNumber = BlockNumber;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+    pub static TotalNumberOfValidators: u32 = 5;
+    pub static MinVotePointsThreshold: u32 = 1;
+    pub static SessionsPerEra: u32 = 5;
+}
+
+impl pallet_infra_voting::Config for TestRuntime {
+    type RuntimeEvent = RuntimeEvent;
+    type SessionsPerEra = SessionsPerEra;
+    type InfraVoteAccountId = VoteAccountId;
+    type InfraVotePoints = VoteWeight;
+    type NextNewSession = Session;
+    type SessionInterface = ();
+}
+
+parameter_types! {
+	pub static ValidatorAccounts: BTreeMap<AccountId, AccountId> = BTreeMap::new();
+}
+
+pub const KEY_TYPE: sp_core::crypto::KeyTypeId = sp_application_crypto::key_types::DUMMY;
+
+mod app {
+    use sp_application_crypto::{app_crypto, key_types::DUMMY, sr25519};
+    app_crypto!(sr25519, DUMMY);
+}
+
+pub type MockAuthorityId = app::Public;
+
+/// Another session handler struct to test on_disabled.
+pub struct OtherSessionHandler;
+impl OneSessionHandler<AccountId> for OtherSessionHandler {
+	type Key = MockAuthorityId;
+
+	fn on_genesis_session<'a, I: 'a>(_: I)
+	where
+		I: Iterator<Item = (&'a AccountId, Self::Key)>,
+		AccountId: 'a,
+	{
+	}
+
+	fn on_new_session<'a, I: 'a>(_: bool, _: I, _: I)
+	where
+		I: Iterator<Item = (&'a AccountId, Self::Key)>,
+		AccountId: 'a,
+	{
+	}
+
+	fn on_disabled(_validator_index: u32) {}
+}
+
+impl sp_runtime::BoundToRuntimeAppPublic for OtherSessionHandler {
+	type Public = MockAuthorityId;
+}
+
+sp_runtime::impl_opaque_keys! {
+	pub struct SessionKeys {
+		pub other: OtherSessionHandler,
+	}
+}
+
+pub struct TestValidatorIdOf;
+impl TestValidatorIdOf {
+	pub fn set(v: BTreeMap<AccountId, AccountId>) {
+		ValidatorAccounts::mutate(|m| *m = v);
+	}
+}
+
+impl Convert<AccountId, Option<AccountId>> for TestValidatorIdOf {
+	fn convert(x: AccountId) -> Option<AccountId> {
+		ValidatorAccounts::get().get(&x).cloned()
+	}
+}
+
+parameter_types! {
+    // Only for test
+    pub static Period: BlockNumber = 5;
+    pub static Offset: BlockNumber = 0;
+}
+impl pallet_session::Config for TestRuntime {
+	type RuntimeEvent = RuntimeEvent;
+    type Keys = SessionKeys;
+	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+    type SessionManager = InfraVoting;
+	type SessionHandler = (OtherSessionHandler,);
+	type ValidatorId = AccountId;
+	type ValidatorIdOf = TestValidatorIdOf;
+	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type WeightInfo = ();
+}
+
+pub struct ExtBuilder {
+	total_number_of_validators: u32,
+	number_of_seed_trust_validators: u32,
+    seed_trust_validators: Vec<AccountId>,
+    initialize_first_session: bool,
+    is_pot_enable_at_genesis: bool,
+    vote_status: Vec<(VoteAccountId, VoteWeight)>
+}
+
+impl Default for ExtBuilder {
+    fn default() -> Self {
+        Self {
+            total_number_of_validators: 3,
+            number_of_seed_trust_validators: 3,
+            seed_trust_validators: vec![],
+            initialize_first_session: true,
+            is_pot_enable_at_genesis: false,
+            vote_status: vec![]
+        }
+    }
+}
+
+impl ExtBuilder{
+    pub fn total_number_of_validators(mut self, total_num: u32) -> Self {
+        self.total_number_of_validators = total_num;
+        self
+    } 
+
+    pub fn number_of_seed_trust_validators(mut self, total_num: u32) -> Self {
+        self.number_of_seed_trust_validators = total_num;
+        self
+    }
+
+    pub fn seed_trust_validators(mut self, seed_trust_validators: Vec<AccountId>) -> Self {
+        self.seed_trust_validators = seed_trust_validators;
+        self
+    }
+
+    pub fn initialize_fist_session(mut self, init: bool) -> Self {
+        self.initialize_first_session = init;
+        self
+    }
+
+    pub fn pot_enable(mut self, is_enable: bool) -> Self {
+        self.is_pot_enable_at_genesis = is_enable;
+        self
+    }
+
+    pub fn vote_status(mut self, create_mock_vote_status: impl FnOnce() -> MockVoteStatus) -> Self {
+        let vote_status = create_mock_vote_status();
+        self.vote_status = vote_status.0;
+        self
+    }
+
+    fn app_public(keyring: sp_keyring::Sr25519Keyring) -> app::Public {
+        match keyring {
+            Alice => app::Public::from_slice(&[0; 32]).unwrap(),
+            Bob => app::Public::from_slice(&[1; 32]).unwrap(),
+            Charlie => app::Public::from_slice(&[2; 32]).unwrap(),
+            Dave => app::Public::from_slice(&[3; 32]).unwrap(),
+            Eve => app::Public::from_slice(&[4; 32]).unwrap(),
+            Ferdie => app::Public::from_slice(&[5; 32]).unwrap(),
+            _ => app::Public::from_slice(&[6; 32]).unwrap(),
+        }
+    }
+
+    fn build(self) -> sp_io::TestExternalities {
+       
+        let mut storage = frame_system::GenesisConfig::default()
+            .build_storage::<TestRuntime>()
+            .unwrap();
+
+        let seed_trust_validators = vec![
+            Alice.to_account_id(),
+            Bob.to_account_id(),
+            Charlie.to_account_id(),
+        ];
+        let account_keyring = vec! [
+            Alice, Bob, Charlie, Dave, Eve, Ferdie
+        ];
+
+        let _ = pallet_infra_voting::GenesisConfig::<TestRuntime> {
+            seed_trust_validators: seed_trust_validators.clone(),
+            total_number_of_validators: self.total_number_of_validators,
+            number_of_seed_trust_validators: self.number_of_seed_trust_validators,
+            is_pot_enable_at_genesis: self.is_pot_enable_at_genesis,
+            vote_status_at_genesis: self.vote_status,
+            ..Default::default()
+        }
+        .assimilate_storage(&mut storage);
+
+        let _ = pallet_session::GenesisConfig::<TestRuntime> {
+            keys: seed_trust_validators
+                .into_iter()
+                .zip(account_keyring)
+                .map(|(id, keyring)| (id.clone(), id.clone(), SessionKeys { other: Self::app_public(keyring) }))
+                .collect()
+        }
+        .assimilate_storage(&mut storage);
+
+        let mut ext = sp_io::TestExternalities::from(storage);
+
+        if self.initialize_first_session {
+            ext.execute_with(|| {
+                System::set_block_number(1);
+                <Session as Hooks<BlockNumber>>::on_initialize(1);
+            });
+        }
+        ext
+    }
+
+    pub fn build_and_execute(self, test: impl FnOnce() -> ()) {
+        let mut ext = self.build();
+        
+        ext.execute_with(test);
+    }
+}
+
+/// Progress to the given block, triggering session and era changes as we progress.
+///
+/// This will finalize the previous block, initialize up to the given block, essentially simulating
+/// a block import/propose process where we first initialize the block, then execute some stuff (not
+/// in the function), and then finalize the block.
+pub(crate) fn progress_block(n: BlockNumber) {
+
+	for b in (System::block_number() + 1)..=n {
+		System::set_block_number(b);
+		Session::on_initialize(b);
+	}
+}
+
+/// Progresses from the current block number (whatever that may be) to the `P * session_index + 1`.
+pub(crate) fn progress_session(session_index: SessionIndex) {
+	let end: BlockNumber = (session_index as BlockNumber) * Period::get();
+	progress_block(end);
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, TypeInfo)]
+pub struct MockVoteStatus(pub Vec<(VoteAccountId, VoteWeight)>);
+
+impl Default for MockVoteStatus {
+    fn default() -> Self {
+        Self(vec![])
+    }
+}
+
+impl From<MockVoteStatus> for VotingStatus<TestRuntime> {
+    fn from(value: MockVoteStatus) -> Self {
+        Self {
+            status: value.0
+        }
+    }
+}
+
+impl MockVoteStatus {
+
+    fn create_mock_account(num: usize) -> Vec<VoteAccountId> {
+        let mut mock_accounts = vec![];
+        let accounts = vec![Dave, Ferdie, Eve];
+        for i in 0..num {
+            mock_accounts.push(accounts[i].to_account_id());
+        }
+        mock_accounts
+    }
+
+    pub fn create_mock_pot(num: usize, is_over_min: bool) -> Self {
+        let mut mock_pot = vec![];
+        let mock_accounts = Self::create_mock_account(num);
+        mock_accounts.into_iter().for_each(|acc| {
+            let min_threshold = MinVotePointsThreshold::get();
+            let vote_point = if !is_over_min && acc == Dave.to_account_id() {
+                min_threshold - 1
+            } else {
+                min_threshold + 1 
+            };
+            mock_pot.push((acc, vote_point as VoteWeight));
+        });
+        Self(mock_pot)
+    }
+
+    pub fn increase_vote_point(&mut self, who: VoteAccountId) {
+        self.0.iter_mut().for_each(|vote_status| {
+            if vote_status.0 == who {
+                vote_status.1 += 1;
+            }
+        })
+    }
+}
+/// There will be three candidates for testing
+/// Dave, Eve, Ferdie
+pub(crate) fn create_mock_vote_status(num: usize, is_over_min: bool) -> MockVoteStatus {
+    
+    MockVoteStatus::create_mock_pot(num, is_over_min)
+} 
+
+pub(crate) fn infra_voting_events() -> Vec<crate::Event<TestRuntime>> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| if let RuntimeEvent::InfraVoting(inner) = e { Some(inner) } else { None })
+		.collect()
+}

--- a/frame/infra-voting/src/tests.rs
+++ b/frame/infra-voting/src/tests.rs
@@ -1,0 +1,105 @@
+
+use frame_support::assert_ok;
+
+use super::{
+    TotalNumberOfValidators as TotalValidatorsNum,
+    NumberOfSeedTrustValidators as SeedTrustNum,
+    *,
+};
+use crate::mock::{*, RuntimeOrigin as TestOrigin};
+
+#[test]
+fn config_works() {
+    ExtBuilder::default().build_and_execute(|| {
+        assert_eq!(TotalValidatorsNum::<TestRuntime>::get(), 3);
+        assert_eq!(SeedTrustNum::<TestRuntime>::get(), 3);
+        assert_eq!(ForceEra::<TestRuntime>::get(), Forcing::NotForcing);
+        assert_eq!(SeedTrustValidatorPool::<TestRuntime>::get().len(), 3);
+        assert_eq!(CurrentEra::<TestRuntime>::get().unwrap(), 0);
+        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+        assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(current_era).unwrap(), 0);
+    });
+}
+
+#[test]
+fn session_and_era_works() {
+    ExtBuilder::default().build_and_execute(|| {
+        assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(0).unwrap(), 0);
+        progress_session(1);
+        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+        assert_eq!(current_era, 0);
+        progress_session(2);
+        progress_session(3);
+        progress_session(4);
+        progress_session(5);
+        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+        assert_eq!(current_era, 1);
+        assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(current_era).unwrap(), 5);
+    })
+}
+
+#[test]
+fn pot_works() {
+    ExtBuilder::default()
+    .pot_enable(true)
+    .vote_status(|| create_mock_vote_status(2, true))
+    .build_and_execute(|| {
+        // Scenario 1
+        // Gensis state
+        assert_eq!(SeedTrustNum::<TestRuntime>::get(), 3);
+        assert_ok!(InfraVoting::set_seed_trust_validators_num(TestOrigin::root(), 2));
+        assert_eq!(SeedTrustNum::<TestRuntime>::get(), 2);
+        assert_eq!(PotValidatorPool::<TestRuntime>::get().counts(), 2);
+        assert_eq!(
+            PotValidatorPool::<TestRuntime>::get().status,
+            vec![
+                (sp_keyring::Sr25519Keyring::Dave.to_account_id(), 2),
+                (sp_keyring::Sr25519Keyring::Ferdie.to_account_id(), 2)
+            ]
+        );
+        // Let's roll to era 1 
+        // We should have 2 Seed Trust and 1 Pot Validator
+        for i in 1..=5 {
+            progress_session(i);
+        }
+        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+        assert_eq!(current_era, 1);
+        assert_eq!(
+            PotValidators::<TestRuntime>::get(1).len(),
+            1
+        );
+        assert_eq!(
+            *infra_voting_events().last().unwrap(), 
+            Event::ValidatorsElected { 
+                validators: vec![
+                    sp_keyring::Sr25519Keyring::Alice.to_account_id(),
+                    sp_keyring::Sr25519Keyring::Bob.to_account_id(),
+                    sp_keyring::Sr25519Keyring::Dave.to_account_id(),
+                ], 
+                pot_enabled: true 
+            }
+        );
+        // Scenario2: Ferdie got more vote
+        // Let's roll to era 2
+        // We should have 2 Seed Trust and 1 Pot Validator
+        let mut mock_vote_status = MockVoteStatus::create_mock_pot(2, true);
+        mock_vote_status.increase_vote_point(sp_keyring::Sr25519Keyring::Ferdie.to_account_id());
+        let voting_status: VotingStatus<TestRuntime> = mock_vote_status.into();
+        PotValidatorPool::<TestRuntime>::put(voting_status);
+        for i in 6..=10 {
+            progress_session(i);
+        }
+        assert_eq!(
+            *infra_voting_events().last().unwrap(), 
+            Event::ValidatorsElected { 
+                validators: vec![
+                    sp_keyring::Sr25519Keyring::Alice.to_account_id(),
+                    sp_keyring::Sr25519Keyring::Bob.to_account_id(),
+                    sp_keyring::Sr25519Keyring::Ferdie.to_account_id(),
+                ], 
+                pot_enabled: true 
+            }
+        );
+    })
+}
+

--- a/frame/infra-voting/src/tests.rs
+++ b/frame/infra-voting/src/tests.rs
@@ -1,105 +1,99 @@
-
 use frame_support::assert_ok;
 
 use super::{
-    TotalNumberOfValidators as TotalValidatorsNum,
-    NumberOfSeedTrustValidators as SeedTrustNum,
-    *,
+	NumberOfSeedTrustValidators as SeedTrustNum, TotalNumberOfValidators as TotalValidatorsNum, *,
 };
-use crate::mock::{*, RuntimeOrigin as TestOrigin};
+use crate::mock::{RuntimeOrigin as TestOrigin, *};
 
 #[test]
 fn config_works() {
-    ExtBuilder::default().build_and_execute(|| {
-        assert_eq!(TotalValidatorsNum::<TestRuntime>::get(), 3);
-        assert_eq!(SeedTrustNum::<TestRuntime>::get(), 3);
-        assert_eq!(ForceEra::<TestRuntime>::get(), Forcing::NotForcing);
-        assert_eq!(SeedTrustValidatorPool::<TestRuntime>::get().len(), 3);
-        assert_eq!(CurrentEra::<TestRuntime>::get().unwrap(), 0);
-        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
-        assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(current_era).unwrap(), 0);
-    });
+	ExtBuilder::default().build_and_execute(|| {
+		assert_eq!(TotalValidatorsNum::<TestRuntime>::get(), 3);
+		assert_eq!(SeedTrustNum::<TestRuntime>::get(), 3);
+		assert_eq!(ForceEra::<TestRuntime>::get(), Forcing::NotForcing);
+		assert_eq!(SeedTrustValidatorPool::<TestRuntime>::get().len(), 3);
+		assert_eq!(CurrentEra::<TestRuntime>::get().unwrap(), 0);
+		let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+		assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(current_era).unwrap(), 0);
+	});
 }
 
 #[test]
 fn session_and_era_works() {
-    ExtBuilder::default().build_and_execute(|| {
-        assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(0).unwrap(), 0);
-        progress_session(1);
-        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
-        assert_eq!(current_era, 0);
-        progress_session(2);
-        progress_session(3);
-        progress_session(4);
-        progress_session(5);
-        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
-        assert_eq!(current_era, 1);
-        assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(current_era).unwrap(), 5);
-    })
+	ExtBuilder::default().build_and_execute(|| {
+		assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(0).unwrap(), 0);
+		progress_session(1);
+		let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+		assert_eq!(current_era, 0);
+		progress_session(2);
+		progress_session(3);
+		progress_session(4);
+		progress_session(5);
+		let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+		assert_eq!(current_era, 1);
+		assert_eq!(StartSessionIndexPerEra::<TestRuntime>::get(current_era).unwrap(), 5);
+	})
 }
 
 #[test]
 fn pot_works() {
-    ExtBuilder::default()
-    .pot_enable(true)
-    .vote_status(|| create_mock_vote_status(2, true))
-    .build_and_execute(|| {
-        // Scenario 1
-        // Gensis state
-        assert_eq!(SeedTrustNum::<TestRuntime>::get(), 3);
-        assert_ok!(InfraVoting::set_seed_trust_validators_num(TestOrigin::root(), 2));
-        assert_eq!(SeedTrustNum::<TestRuntime>::get(), 2);
-        assert_eq!(PotValidatorPool::<TestRuntime>::get().counts(), 2);
-        assert_eq!(
-            PotValidatorPool::<TestRuntime>::get().status,
-            vec![
-                (sp_keyring::Sr25519Keyring::Dave.to_account_id(), 2),
-                (sp_keyring::Sr25519Keyring::Ferdie.to_account_id(), 2)
-            ]
-        );
-        // Let's roll to era 1 
-        // We should have 2 Seed Trust and 1 Pot Validator
-        for i in 1..=5 {
-            progress_session(i);
-        }
-        let current_era = CurrentEra::<TestRuntime>::get().unwrap();
-        assert_eq!(current_era, 1);
-        assert_eq!(
-            PotValidators::<TestRuntime>::get(1).len(),
-            1
-        );
-        assert_eq!(
-            *infra_voting_events().last().unwrap(), 
-            Event::ValidatorsElected { 
-                validators: vec![
-                    sp_keyring::Sr25519Keyring::Alice.to_account_id(),
-                    sp_keyring::Sr25519Keyring::Bob.to_account_id(),
-                    sp_keyring::Sr25519Keyring::Dave.to_account_id(),
-                ], 
-                pot_enabled: true 
-            }
-        );
-        // Scenario2: Ferdie got more vote
-        // Let's roll to era 2
-        // We should have 2 Seed Trust and 1 Pot Validator
-        let mut mock_vote_status = MockVoteStatus::create_mock_pot(2, true);
-        mock_vote_status.increase_vote_point(sp_keyring::Sr25519Keyring::Ferdie.to_account_id());
-        let voting_status: VotingStatus<TestRuntime> = mock_vote_status.into();
-        PotValidatorPool::<TestRuntime>::put(voting_status);
-        for i in 6..=10 {
-            progress_session(i);
-        }
-        assert_eq!(
-            *infra_voting_events().last().unwrap(), 
-            Event::ValidatorsElected { 
-                validators: vec![
-                    sp_keyring::Sr25519Keyring::Alice.to_account_id(),
-                    sp_keyring::Sr25519Keyring::Bob.to_account_id(),
-                    sp_keyring::Sr25519Keyring::Ferdie.to_account_id(),
-                ], 
-                pot_enabled: true 
-            }
-        );
-    })
+	ExtBuilder::default()
+		.pot_enable(true)
+		.vote_status(|| create_mock_vote_status(2, true))
+		.build_and_execute(|| {
+			// Scenario 1
+			// Gensis state
+			assert_eq!(SeedTrustNum::<TestRuntime>::get(), 3);
+			assert_ok!(InfraVoting::set_seed_trust_validators_num(TestOrigin::root(), 2));
+			assert_eq!(SeedTrustNum::<TestRuntime>::get(), 2);
+			assert_eq!(PotValidatorPool::<TestRuntime>::get().counts(), 2);
+			assert_eq!(
+				PotValidatorPool::<TestRuntime>::get().status,
+				vec![
+					(sp_keyring::Sr25519Keyring::Dave.to_account_id(), 2),
+					(sp_keyring::Sr25519Keyring::Ferdie.to_account_id(), 2)
+				]
+			);
+			// Let's roll to era 1
+			// We should have 2 Seed Trust and 1 Pot Validator
+			for i in 1..=5 {
+				progress_session(i);
+			}
+			let current_era = CurrentEra::<TestRuntime>::get().unwrap();
+			assert_eq!(current_era, 1);
+			assert_eq!(PotValidators::<TestRuntime>::get(1).len(), 1);
+			assert_eq!(
+				*infra_voting_events().last().unwrap(),
+				Event::ValidatorsElected {
+					validators: vec![
+						sp_keyring::Sr25519Keyring::Alice.to_account_id(),
+						sp_keyring::Sr25519Keyring::Bob.to_account_id(),
+						sp_keyring::Sr25519Keyring::Dave.to_account_id(),
+					],
+					pot_enabled: true
+				}
+			);
+			// Scenario2: Ferdie got more vote
+			// Let's roll to era 2
+			// We should have 2 Seed Trust and 1 Pot Validator
+			let mut mock_vote_status = MockVoteStatus::create_mock_pot(2, true);
+			mock_vote_status
+				.increase_vote_point(sp_keyring::Sr25519Keyring::Ferdie.to_account_id());
+			let voting_status: VotingStatus<TestRuntime> = mock_vote_status.into();
+			PotValidatorPool::<TestRuntime>::put(voting_status);
+			for i in 6..=10 {
+				progress_session(i);
+			}
+			assert_eq!(
+				*infra_voting_events().last().unwrap(),
+				Event::ValidatorsElected {
+					validators: vec![
+						sp_keyring::Sr25519Keyring::Alice.to_account_id(),
+						sp_keyring::Sr25519Keyring::Bob.to_account_id(),
+						sp_keyring::Sr25519Keyring::Ferdie.to_account_id(),
+					],
+					pot_enabled: true
+				}
+			);
+		})
 }
-

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -569,7 +569,6 @@ pub mod pallet {
 		/// block of the current session.
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if T::ShouldEndSession::should_end_session(n) {
-		
 				Self::rotate_session();
 				T::BlockWeights::get().max_block
 			} else {
@@ -631,7 +630,6 @@ impl<T: Config> Pallet<T> {
 	pub fn rotate_session() {
 		let session_index = <CurrentIndex<T>>::get();
 		log::trace!(target: "runtime::session", "rotating session {:?}", session_index);
-	
 
 		let changed = <QueuedChanged<T>>::get();
 

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -466,6 +466,7 @@ pub mod pallet {
 					);
 					self.keys.iter().map(|x| x.1.clone()).collect()
 				});
+
 			assert!(
 				!initial_validators_0.is_empty(),
 				"Empty validator set for session 0 in genesis block!"
@@ -568,6 +569,7 @@ pub mod pallet {
 		/// block of the current session.
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if T::ShouldEndSession::should_end_session(n) {
+		
 				Self::rotate_session();
 				T::BlockWeights::get().max_block
 			} else {
@@ -629,6 +631,7 @@ impl<T: Config> Pallet<T> {
 	pub fn rotate_session() {
 		let session_index = <CurrentIndex<T>>::get();
 		log::trace!(target: "runtime::session", "rotating session {:?}", session_index);
+	
 
 		let changed = <QueuedChanged<T>>::get();
 


### PR DESCRIPTION
### Summary
This PR includes _Proof of Transaction_ mechanism

#### Session Pallet
- It is coupled with `Session` pallet and change its validator set for every `Era`
- Era can be divided into a number of `Session` 
- For every `Session`, Runtime checks whether to start new era

#### Election
- There are total(max) number of validators set and number of _Seed Trust_ validators that can be elected.
- PoT validators can be elected based on the number of Seed Trust validators. Let's say we have total **N** validators and `S` number of Seed Trust validators that can be elected. Then, `N - S` number of PoT validators can be elected 
- PoT validators will be elected based on the `Vote Points`

#### Terminology
1. Vote Points
- Converted vote weight based on `InfraExchange` pallet

2. Era
- Period that validators set changed

3. Session
- number of session = era

### Describe your changes
#### Config

`SessionPerEra`

Number of sessions per era

`InfraVoteAccountId`

Simply `VoteAccountId` type that should be same type as `frame_system::Config::AccountId`

`InfraVotePoints`

Simply `VoteWeight` type

`NextNewSession`

Type that can estimate the next session change. Usually `Session` pallet

`SessionInterface`

Interface for interacting with `Session` pallet. Usually `Self`


#### Storage

`CurrentEra`

Latest planned era. This will increase whenever `trigger_new_era` is called

`PotValidatorPool`

Pool that tracks all the voting status. Contains `VotingStatus`
```rust
struct VotingStatus {
    status: Vec<(VoteAccountId, VotePoints)>
}
```
`SeedTrustValidatorPool`

Validators set of Seed Trust which hasn't elected. Seed Trust validators would be elected from here.

`PotValidators`

Validator that have been elected by PoT at certain era.

`NumberOfSeedTrustValidators`

Number of seed trust validators that can be elected. Should be less or equal to `TotalNumberOfValidators`

`TotalNumberOfValidators`

Total Number of validators that can be elected, which is composed of seed trust validators and pot validators

`MinVotePointsThreshold`

Minimum threshold of vote points to be eligible as PoT validator

`ForceEra`

Mode of force era. This acts as safe guard for liveliness of Era

#### Extrinsics

`set_seed_trust_validators_num`

Change number of seed trust validators that can be elected. Origin is `Root`

`set_total_number_of_validators`

Change number of total validators that can be elected. Origin is `Root`

`add_seed_trust_validator`

Add seed trust validator to `SeedTrustValidatorPool`



### Related Issue
#26 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Well documented code
- [x] `cargo clippy`
- [x] `cargo-nightly fmt`
