### PR TITLE
add `force_create_with_metadata` in pallet-assets

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -931,4 +931,20 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			.filter_map(|id| Self::maybe_balance(id, account.clone()).map(|balance| (id, balance)))
 			.collect::<Vec<_>>()
 	}
+
+	/// Returns most balance for the given asset id.
+	pub fn get_most_account_balance(
+		asset_ids: impl IntoIterator<Item = T::AssetId>,
+		account: T::AccountId,
+	) -> Option<(T::AssetId, T::Balance)> {
+		let mut most_balance: Option<(T::AssetId, T::Balance)> = None;
+		for asset_id in asset_ids {
+			if let Some(balance) = Self::maybe_balance(asset_id, account.clone()) {
+				if None == most_balance || (most_balance.unwrap().1 < balance) {
+					most_balance = Some((asset_id, balance));
+				}
+			}
+		}
+		most_balance
+	}
 }

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -1673,8 +1673,8 @@ pub mod pallet {
 			let bounded_symbol: BoundedVec<u8, T::StringLimit> =
 				symbol.clone().try_into().map_err(|_| Error::<T, I>::BadMetadata)?;
 
-			ensure!(Asset::<T, I>::contains_key(id), Error::<T, I>::Unknown);
 			let _ = Self::do_force_create(id, owner, is_sufficient, min_balance);
+			ensure!(Asset::<T, I>::contains_key(id), Error::<T, I>::Unknown);
 			Metadata::<T, I>::try_mutate_exists(id, |metadata| {
 				let deposit = metadata.take().map_or(Zero::zero(), |m| m.deposit);
 				*metadata = Some(AssetMetadata {


### PR DESCRIPTION
### Summary
* Relay chain -> Parachain dmp로 `force_create` + `force_set_metadata` 를 수행해야 하는 경우가 있음 (`register_wrapped_system_token`)
* Transact message 2개 이상 송신시 Weight 초과로 처리되지 않거나, 처리 자체를 하지않는 이슈가 있음

### Describe your changes
```rust
		pub fn force_create_with_metadata(
			origin: OriginFor<T>,
			id: T::AssetIdParameter,
			owner: AccountIdLookupOf<T>,
			is_sufficient: bool,
			#[pallet::compact] min_balance: T::Balance,
			name: Vec<u8>,
			symbol: Vec<u8>,
			decimals: u8,
			is_frozen: bool,
		) -> DispatchResult {
			T::ForceOrigin::ensure_origin(origin)?;
			let owner = T::Lookup::lookup(owner)?;
                        /* snip */
                }
```

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Well documented code
- [x] `cargo clippy`
- [x] `cargo-nightly fmt`
