### PR TITLE
enhance the asset pallet adding AssetLinkInterface

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -300,6 +300,7 @@ impl pallet_assets::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
 	type AssetId = AssetId;
+	type AssetLink = ();
 	type AssetIdParameter = codec::Compact<AssetId>;
 	type Currency = Balances;
 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId>>;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1480,6 +1480,7 @@ impl pallet_assets::Config for Runtime {
 	type Balance = u128;
 	type AssetId = u32;
 	type AssetIdParameter = codec::Compact<u32>;
+	type AssetLink = ();
 	type Currency = Balances;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type ForceOrigin = EnsureRoot<AccountId>;

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -1756,7 +1756,7 @@ where
 	fn link_system_token(
 		origin: OriginFor<T>,
 		asset_id: AssetIdOf<T, I>,
-		multilocation: SystemTokenId,
+		system_token_id: SystemTokenId,
 	) -> DispatchResult;
 
 	fn unlink_system_token(origin: OriginFor<T>, asset_id: AssetIdOf<T, I>) -> DispatchResult;
@@ -1770,7 +1770,7 @@ where
 	fn link_system_token(
 		_origin: OriginFor<T>,
 		_asset_id: AssetIdOf<T, I>,
-		_multilocation: SystemTokenId,
+		_system_token_id: SystemTokenId,
 	) -> DispatchResult {
 		Ok(())
 	}

--- a/frame/assets/src/mock.rs
+++ b/frame/assets/src/mock.rs
@@ -104,6 +104,7 @@ impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = u64;
 	type AssetId = u32;
+	type AssetLink = ();
 	type AssetIdParameter = u32;
 	type Currency = Balances;
 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<u64>>;

--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -220,7 +220,7 @@ pub enum ConversionError {
 // Type alias for `frame_system`'s account id.
 type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 // This pallet's asset id and balance type.
-type AssetIdOf<T, I> = <T as Config<I>>::AssetId;
+pub(crate) type AssetIdOf<T, I> = <T as Config<I>>::AssetId;
 type AssetBalanceOf<T, I> = <T as Config<I>>::Balance;
 // Generic fungible balance type.
 type BalanceOf<F, T> = <F as fungible::Inspect<AccountIdOf<T>>>::Balance;

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -102,7 +102,7 @@
 use sp_runtime::{traits::StaticLookup, DispatchResult};
 use sp_std::prelude::*;
 
-use frame_support::{dispatch::GetDispatchInfo, traits::{UnfilteredDispatchable, EnsureOrigin}};
+use frame_support::{dispatch::GetDispatchInfo, traits::UnfilteredDispatchable};
 
 mod extension;
 #[cfg(test)]
@@ -228,15 +228,11 @@ pub mod pallet {
 		/// Remove sudo key
 		#[pallet::call_index(3)]
 		#[pallet::weight(1000)]
-		pub fn remove_key(
-			origin: OriginFor<T>,
-		) -> DispatchResultWithPostInfo {
+		pub fn remove_key(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			ensure!(Self::key().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
 			Key::<T>::kill();
-			Self::deposit_event(
-				Event::<T>::SudoKeyRemoved
-			);
+			Self::deposit_event(Event::<T>::SudoKeyRemoved);
 			Ok(Pays::No.into())
 		}
 	}

--- a/primitives/runtime/src/types/token.rs
+++ b/primitives/runtime/src/types/token.rs
@@ -8,7 +8,7 @@ use sp_std::prelude::*;
 use serde::{Deserialize, Serialize};
 
 pub type ParaId = u32;
-pub type PalletId = u32;
+pub type PalletId = u8;
 pub type AssetId = u32;
 
 /// Data structure for Original system tokens
@@ -40,7 +40,7 @@ pub struct SystemTokenId {
 }
 
 impl SystemTokenId {
-	pub fn new(para_id: u32, pallet_id: u32, asset_id: AssetId) -> Self {
+	pub fn new(para_id: u32, pallet_id: u8, asset_id: AssetId) -> Self {
 		Self { para_id, pallet_id, asset_id }
 	}
 }


### PR DESCRIPTION
### Summary
- methods of the `asset-link` pallet are merged into the `asset` pallet to reduce the number of DMP calls.

### Describe your changes
- AssetLinkInterface trait is added.
```rust
pub trait AssetLinkInterface<T, I = ()>
where
	T: frame_system::Config + pallet::Config<I>,
	I: 'static,
{
	fn link_system_token(
		origin: OriginFor<T>, asset_id: AssetIdOf<T, I>, multilocation: SystemTokenId,
	) -> DispatchResult;

	fn unlink_system_token(origin: OriginFor<T>, asset_id: AssetIdOf<T, I>) -> DispatchResult;
}
```
- ParaId type is changed from u32 to 'u8'

### Related Issue
* #54 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Well documented code
- [x] `cargo clippy`
- [x] `cargo-nightly fmt`
