### PR TITLE
refactor assets pallet to apply SystemTokenWeight

### DIFF
--- a/bin/node-template/node/src/chain_spec.rs
+++ b/bin/node-template/node/src/chain_spec.rs
@@ -154,7 +154,7 @@ fn testnet_genesis(
 				true,                                                 // is_sufficient
 				1,                                                    // min_balance(= 0.01 iTest)
 			)],
-			metadata: vec![(99, "iTEST".into(), "iTEST".into(), 2)],
+			metadata: vec![(99, "iUSD".into(), "iUSD".into(), 5)],
 			accounts: vec![(
 				99,
 				get_account_id_from_seed::<sr25519::Public>("Alice"),

--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -659,7 +659,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				sufficients: 0,
 				approvals: 0,
 				status: AssetStatus::Live,
-				system_token_weight: 1,
+				system_token_weight: 100000,
 			},
 		);
 		Self::deposit_event(Event::ForceCreated { asset_id: id, owner: owner.clone() });

--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -659,6 +659,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				sufficients: 0,
 				approvals: 0,
 				status: AssetStatus::Live,
+				system_token_weight: 1,
 			},
 		);
 		Self::deposit_event(Event::ForceCreated { asset_id: id, owner: owner.clone() });

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -406,6 +406,7 @@ pub mod pallet {
 						sufficients: 0,
 						approvals: 0,
 						status: AssetStatus::Live,
+						system_token_weight: 1,
 					},
 				);
 			}
@@ -631,6 +632,7 @@ pub mod pallet {
 					sufficients: 0,
 					approvals: 0,
 					status: AssetStatus::Live,
+					system_token_weight: 1,
 				},
 			);
 

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -642,7 +642,7 @@ pub mod pallet {
 					sufficients: 0,
 					approvals: 0,
 					status: AssetStatus::Live,
-					system_token_weight: 1,
+					system_token_weight: 100000,
 				},
 			);
 

--- a/frame/assets/src/migration.rs
+++ b/frame/assets/src/migration.rs
@@ -37,6 +37,7 @@ pub mod v1 {
 		pub sufficients: u32,
 		pub approvals: u32,
 		pub is_frozen: bool,
+		pub system_token_weight: u128,
 	}
 
 	impl<Balance, AccountId, DepositBalance> OldAssetDetails<Balance, AccountId, DepositBalance> {
@@ -56,6 +57,7 @@ pub mod v1 {
 				sufficients: self.sufficients,
 				approvals: self.approvals,
 				status,
+				system_token_weight: self.system_token_weight,
 			}
 		}
 	}

--- a/frame/assets/src/migration.rs
+++ b/frame/assets/src/migration.rs
@@ -37,7 +37,7 @@ pub mod v1 {
 		pub sufficients: u32,
 		pub approvals: u32,
 		pub is_frozen: bool,
-		pub system_token_weight: u128,
+		pub system_token_weight: u64,
 	}
 
 	impl<Balance, AccountId, DepositBalance> OldAssetDetails<Balance, AccountId, DepositBalance> {

--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -69,6 +69,8 @@ pub struct AssetDetails<Balance, AccountId, DepositBalance> {
 	pub(super) approvals: u32,
 	/// The status of the asset
 	pub(super) status: AssetStatus,
+	/// The system token weight compared with iUSD.
+	pub(super) system_token_weight: u128,
 }
 
 /// Data concerning an approval.
@@ -262,7 +264,7 @@ where
 		let balance = CON::convert(balance);
 		// balance * asset.min_balance / min_balance(1_000_000)
 		// ToDo: Divisor should be changed based on the decimals
-		Ok(FixedU128::saturating_from_rational(asset.min_balance, 1_000_000u128)
+		Ok(FixedU128::saturating_from_rational(1, asset.system_token_weight)
 			.saturating_mul_int(balance))
 	}
 }


### PR DESCRIPTION
# Summary
- SystemTokenWeight is a ratio related decimal and exchange rate between each system token and usd(base system token).
- SystemTokenWeight is added into `AssetDetails` of Assets pallet.
- ParaFeeRate is newly added to Asset pallet.
- BalanceToAssetBalance struct is changed to consider SystemTokenWeight in the Assets pallet.
- `fn update_system_token_weight` and `fn update_para_fee_rate` is newly added to be called by the dmp from relay chain

# Describe your changes
- system_token_weight has been added to the AssetDetails like the following
```rust
pub struct AssetDetails<Balance, AccountId, DepositBalance> {
	/// Can change `owner`, `issuer`, `freezer` and `admin` accounts.
	pub(super) owner: AccountId,
	/// Can mint tokens.
	pub(super) issuer: AccountId,
	...
	/// The system token weight compared with iUSD.
	pub(super) system_token_weight: u128,
}
```
- BalanceToAssetBalance type has been changed to the following. This means that the asset balance eqauls `Balance * para_fee_rate / asset.system_token_weight` 
```rust
FixedU128::saturating_from_rational(
			para_fee_rate,
			asset.system_token_weight * CORRECTION_PARA_FEE_RATE,)
		.saturating_mul_int(balance))
```
- ParaFeeRate is initilzed as 1_000(1.0), then it SHOULD be only set by a dmp call from RELAY CHAIN.
```rust
pub(super) type ParaFeeRate<T: Config<I>, I: 'static = ()> = StorageValue<_, u32, OptionQuery>;
```
- `fn update_system_token_weight` and `fn update_para_fee_rate`
```rust
pub fn update_system_token_weight(
			origin: OriginFor<T>,
			id: T::AssetIdParameter,
			system_token_weight: u64,
		) -> DispatchResult {
			T::ForceOrigin::ensure_origin(origin.clone())?;
			let id: T::AssetId = id.into();

			let mut details = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;

			details.system_token_weight = system_token_weight;
			Asset::<T, I>::insert(&id, details);

			Self::deposit_event(Event::AssetSystemTokenWeightChanged {
				asset_id: id,
				system_token_weight,
			});
			Ok(())
		}

pub fn update_para_fee_rate(origin: OriginFor<T>, para_fee_rate: u32) -> DispatchResult {
			T::ForceOrigin::ensure_origin(origin.clone())?;

			ParaFeeRate::<T, I>::set(Some(para_fee_rate));
			Self::deposit_event(Event::ParaFeeRateUpdated { para_fee_rate });
			Ok(())
		}
```
### Related Issue
* #58 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Well documented code
- [ ] `cargo clippy`
- [ ] `cargo-nightly fmt`
