### PR TITLE
Feature/60 design blockweight

### DIFF
--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -29,7 +29,7 @@ pub(super) type DepositBalanceOf<T, I = ()> =
 pub(super) type AssetAccountOf<T, I> =
 	AssetAccount<<T as Config<I>>::Balance, DepositBalanceOf<T, I>, <T as Config<I>>::Extra>;
 
-const CORRECTION_PARA_FEE_RATE: SystemTokenWeight = 1_000;
+const CORRECTION_PARA_FEE_RATE: SystemTokenWeight = 1_000_000;
 
 /// AssetStatus holds the current state of the asset. It could either be Live and available for use,
 /// or in a Destroying state.
@@ -268,7 +268,6 @@ where
 		let para_fee_rate = ParaFeeRate::<T, I>::get().ok_or(ConversionError::AssetMissing)?;
 
 		// balance * para_fee_rate / (system_token_weight * correction_para_fee_rate)
-		// ToDo: Divisor should be changed based on the decimals
 		Ok(FixedU128::saturating_from_rational(
 			para_fee_rate,
 			asset.system_token_weight * CORRECTION_PARA_FEE_RATE,

--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -29,7 +29,7 @@ pub(super) type DepositBalanceOf<T, I = ()> =
 pub(super) type AssetAccountOf<T, I> =
 	AssetAccount<<T as Config<I>>::Balance, DepositBalanceOf<T, I>, <T as Config<I>>::Extra>;
 
-const CORRECTION_PARA_FEE_RATE: SystemTokenWeight = 1_000_000;
+const DEFAULT_PARA_FEE_RATE: SystemTokenWeight = 1_000_000;
 
 /// AssetStatus holds the current state of the asset. It could either be Live and available for use,
 /// or in a Destroying state.
@@ -270,7 +270,7 @@ where
 		// balance * para_fee_rate / (system_token_weight * correction_para_fee_rate)
 		Ok(FixedU128::saturating_from_rational(
 			para_fee_rate,
-			asset.system_token_weight * CORRECTION_PARA_FEE_RATE,
+			asset.system_token_weight * DEFAULT_PARA_FEE_RATE,
 		)
 		.saturating_mul_int(balance))
 	}


### PR DESCRIPTION
### Summary
* change base system token weight to 10^9 
* Increase the precision of ParaFeeRate: 10^3 -> 10^6


### Describe your changes
* satisfying below condition, changed the base system token weight to 10^9
    - Asset transfer(weight :38_562_000) ~= 0.015 Dot (in the polkadot relay chain) ~= 0.06 iUSD

### Related Issue
* #60

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Well documented code
- [ ] `cargo clippy`
- [ ] `cargo-nightly fmt`
